### PR TITLE
Use RSA_ENCRYPT_OR_SIGN for generated keys

### DIFF
--- a/app/src/androidTest/java/co/krypt/krypton/PGPCodesignTest.java
+++ b/app/src/androidTest/java/co/krypt/krypton/PGPCodesignTest.java
@@ -50,7 +50,7 @@ public class PGPCodesignTest {
         SignedSignatureAttributes parsedSig = SignedSignatureAttributes.parse(new DataInputStream(new ByteArrayInputStream(serializedSig)));
 
         Assert.assertTrue(parsedSig.attributes.attributes.hashAlgorithm == HashAlgorithm.SHA512);
-        Assert.assertTrue(parsedSig.attributes.attributes.pkAlgorithm == PublicKeyAlgorithm.RSA_SIGN_ONLY);
+        Assert.assertTrue(parsedSig.attributes.attributes.pkAlgorithm == PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN);
         Assert.assertTrue(parsedSig.attributes.attributes.type == SignatureType.BINARY);
         Assert.assertFalse(parsedSig.attributes.attributes.unhashedSubpackets.issuer.header.type.critical);
     }

--- a/app/src/main/java/co/krypt/krypton/crypto/RSASSHKeyPair.java
+++ b/app/src/main/java/co/krypt/krypton/crypto/RSASSHKeyPair.java
@@ -225,7 +225,7 @@ public class RSASSHKeyPair implements SSHKeyPairI {
     public PublicKeyPacketAttributes pgpPublicKeyPacketAttributes() {
         return new PublicKeyPacketAttributes(
                 created,
-                PublicKeyAlgorithm.RSA_SIGN_ONLY
+                PublicKeyAlgorithm.RSA_ENCRYPT_OR_SIGN
         );
     }
 


### PR DESCRIPTION
The value RSA_SIGN_ONLY is deprecated in OpenPGP specification, being
replaced by key flags. RSA_SIGN_ONLY is not supported by all GnuPG
versions, so RSA_ENCRYPT_OR_SIGN should be used for compatibility.

I agree to license all rights to my contributions in each modified file
exclusively to KryptCo, Inc.